### PR TITLE
#9 #10 #31

### DIFF
--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -16,13 +16,13 @@
 namespace smd2{
 	block::block(const struct block *copy) {
 		memcpy(this,copy,sizeof(struct block));
-	};
+	}
 	block::block(const unsigned int id, const unsigned int hp, const bool active, const unsigned int orientation) {
 		this->id=id;
 		this->hp=hp;
 		this->active=active;
 		this->orientation=orientation;
-	};
+	}
 	block::block(const rawBlock *raw, const blocktypeList *list) {
 		if(!list) throw std::invalid_argument("the provided list may not be NULL");
 		uint32_t buff=0;
@@ -51,13 +51,13 @@ namespace smd2{
 			this->active=false;
 			this->orientation=0;
 		}
-	};
+	}
 	block::block() {
 		this->id=0;
 		this->hp=0;
 		this->active=false;
 		this->orientation=0;
-	};
+	}
 	rawBlock *block::toRaw(rawBlock *target, const blocktypeList *list) {
 		if(!list) throw std::invalid_argument("the provided list may not be NULL");
 		blockType type=((blockType*)list)[this->id];
@@ -81,7 +81,7 @@ namespace smd2{
 		buff=htonl(buff);
 		memcpy(target,&buff+sizeof(uint32_t)-sizeof(rawBlock),sizeof(rawBlock));
 		return target;
-	};
+	}
 	
 	rawChunkData *inflate(rawChunkData *trg,const compressedChunkData *src) {
 		uLongf size = sizeof(rawChunkData);
@@ -101,15 +101,13 @@ namespace smd2{
 		}
 		for(unsigned int x = 0 ; x < 16 ; ++x)
 			for(unsigned int y = 0 ; y < 16 ; ++y)
-				for(unsigned int z = 0 ; z < 16 ; ++z) {
-					(*trg)[x][y][z][0]=buf[x+(16*y)+(256*z)];
-					(*trg)[x][y][z][1]=buf[x+(16*y)+(256*z)+1];
-					(*trg)[x][y][z][2]=buf[x+(16*y)+(256*z)+2];
-				}
+				for(unsigned int z = 0 ; z < 16 ; ++z)
+					for(unsigned int k = 0 ; k < 3 ; ++k)
+						(*trg)[x][y][z][k]=buf[x+(16*y)+(256*z)+k];
 		return trg;
 	}
 	
-	compressedChunkData *deflate(compressedChunkData *trg,const rawChunkData *src) {}; //TODO #32
+	compressedChunkData *deflate(compressedChunkData *trg,const rawChunkData *src) {} //TODO #32
 	
 	bool isEmpty(const rawCompressedSegment *segment) {
 		size_t *chars=(size_t*)segment;
@@ -117,11 +115,11 @@ namespace smd2{
 			if(chars[i]) return false;
 		}
 		return true;
-	};
+	}
 	
 	segmentHead::segmentHead(const struct segmentHead *copy) {
 		memcpy(this,copy,sizeof(struct segmentHead));
-	};
+	}
 	segmentHead::segmentHead(const unsigned char unknownChar, const unsigned long long timestamp, const signed long x, const signed long y, const signed long z, const unsigned char type, const unsigned long inlen) {
 		this->unknownChar=unknownChar;
 		this->timestamp=timestamp;
@@ -130,7 +128,7 @@ namespace smd2{
 		this->z=z;
 		this->type=type;
 		this->inlen=inlen;
-	};
+	}
 	segmentHead::segmentHead(const rawCompressedSegment *raw,const bool offset) {
 		size_t i=0;
 		char *chars=(char*)raw;
@@ -165,7 +163,7 @@ namespace smd2{
 		
 		memcpy(&dbuff32,&(chars[i]),sizeof(uint32_t));
 		this->inlen=ntohl(dbuff32);
-	};
+	}
 	segmentHead::segmentHead() {
 		this->unknownChar=0;
 		this->timestamp=0;
@@ -174,7 +172,7 @@ namespace smd2{
 		this->z=0;
 		this->type=0;
 		this->inlen=0;
-	};
+	}
 	rawCompressedSegment *segmentHead::toRaw(rawCompressedSegment *target,const bool offset) {
 		size_t i=0;
 		char *chars=(char*)target;
@@ -209,15 +207,15 @@ namespace smd2{
 		dbuff32=htonl(this->inlen);
 		memcpy(&(chars[i]),&dbuff32,sizeof(uint32_t));
 		return target;
-	};
+	}
 	
 	segment::segment(const struct segment *copy) {
 		memcpy(this,copy,sizeof(struct segment));
-	};
+	}
 	segment::segment(const struct segmentHead *head,const chunkData *blocks) {
 		this->head=*head;
 		memcpy(&(this->blocks),blocks,sizeof(chunkData));
-	};
+	}
 	
 	static inline void inplaceRawChunkToChunk(chunkData& tgt,
 											  const rawChunkData& src,
@@ -231,7 +229,7 @@ namespace smd2{
 	segment::segment(const struct segmentHead *head,const rawChunkData *blocks,const blocktypeList *list):
 	head(*head) {
 		inplaceRawChunkToChunk(this->blocks, (*blocks), list);
-	};
+	}
 	
 	segment::segment(const struct segmentHead *head,const compressedChunkData *blocks, const blocktypeList* list):
 	head(*head) {
@@ -254,84 +252,84 @@ namespace smd2{
 		inplaceRawChunkToChunk(blocks, rawBlocks, list);
 	}
 	
-	segment::segment(const rawCompressedSegment *src) {}; //TODO #11
-	rawCompressedSegment *segment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {}; //TODO #12
+	segment::segment(const rawCompressedSegment *src) {} //TODO #11
+	rawCompressedSegment *segment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {} //TODO #12
 	
 	rawSegment::rawSegment(const struct rawSegment *copy) {
 		memcpy(this,copy,sizeof(struct rawSegment));
-	};
+	}
 	rawSegment::rawSegment(const struct segmentHead *head,const rawChunkData *blocks) {
 		this->head=*head;
 		memcpy(&(this->blocks),blocks,sizeof(rawChunkData));
-	};
-	rawSegment::rawSegment(const struct segmentHead *head,const chunkData*) {}; //TODO #15
-	rawSegment::rawSegment(const struct segmentHead *head,const compressedChunkData*) {}; //TODO #16
-	rawSegment::rawSegment(const struct segment *src) {}; //TODO #15
-	rawSegment::rawSegment(const struct compressedSegment *src) {}; //TODO #16
-	rawSegment::rawSegment(const rawCompressedSegment *src) {}; //TODO #17
-	rawCompressedSegment *rawSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {}; //TODO #18
+	}
+	rawSegment::rawSegment(const struct segmentHead *head,const chunkData*) {} //TODO #15
+	rawSegment::rawSegment(const struct segmentHead *head,const compressedChunkData*) {} //TODO #16
+	rawSegment::rawSegment(const struct segment *src) {} //TODO #15
+	rawSegment::rawSegment(const struct compressedSegment *src) {} //TODO #16
+	rawSegment::rawSegment(const rawCompressedSegment *src) {} //TODO #17
+	rawCompressedSegment *rawSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {} //TODO #18
 	
 	compressedSegment::compressedSegment(const struct compressedSegment *copy) {
 		memcpy(this,copy,sizeof(struct compressedSegment));
-	};
+	}
 	compressedSegment::compressedSegment(const struct segmentHead *head,const compressedChunkData *blocks) {
 		this->head=*head;
 		memcpy(&(this->blocks),blocks,sizeof(compressedChunkData));
-	};
-	compressedSegment::compressedSegment(const struct segmentHead *head,const chunkData *blocks) {}; //TODO #21
-	compressedSegment::compressedSegment(const struct segmentHead *head,const rawChunkData *blocks) {}; //TODO #22
-	compressedSegment::compressedSegment(const struct segment *src) {}; //TODO #21
-	compressedSegment::compressedSegment(const struct rawSegment *src) {}; //TODO #22
-	compressedSegment::compressedSegment(const rawCompressedSegment *src) {}; //TODO #23
-	rawCompressedSegment *compressedSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {}; //TODO #24
+	}
+	compressedSegment::compressedSegment(const struct segmentHead *head,const chunkData *blocks) {} //TODO #21
+	compressedSegment::compressedSegment(const struct segmentHead *head,const rawChunkData *blocks) {} //TODO #22
+	compressedSegment::compressedSegment(const struct segment *src) {} //TODO #21
+	compressedSegment::compressedSegment(const struct rawSegment *src) {} //TODO #22
+	compressedSegment::compressedSegment(const rawCompressedSegment *src) {} //TODO #23
+	rawCompressedSegment *compressedSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {} //TODO #24
 	
 	
 	smd2Index::smd2Index(const struct smd2Index *copy) {
 		this->id=copy->id;
 		this->inlen=copy->inlen;
-	};
+	}
 	smd2Index::smd2Index(const signed long id, const unsigned long len) {
 		this->id=id;
 		this->inlen=len;
-	};
+	}
 	smd2Index::smd2Index() {
 		this->id=-1;
 		this->inlen=0;
-	};
+	}
 	smd2Index::smd2Index(const rawSmd2Index *raw) {
 		uint32_t split[2];
 		memcpy(split,raw,sizeof(rawSmd2Index));
 		this->id=ntohl(split[0]);
 		this->inlen=ntohl(split[1]);
-	};
+	}
 	rawSmd2Index *smd2Index::toRaw(rawSmd2Index *trg) {
 		uint32_t split[2];
 		split[0]=htonl(this->id);
 		split[1]=htonl(this->inlen);
 		memcpy(trg,split,sizeof(rawSmd2Index));
 		return trg;
-	};
+	}
 	bool smd2Index::isValid() {
 		return this->id!=-1;
-	};
+	}
 	
 	smd2Head::smd2Head(const struct smd2Head *copy) {
 		memcpy(this,copy,sizeof(struct smd2Head));
-	};
+	}
 	smd2Head::smd2Head(const unsigned long version, const fullSmd2Index *index,const fullSmd2TimestampHead *timestamps) {
 		this->version=version;
 		memcpy(&(this->index),index,sizeof(fullSmd2Index));
 		memcpy(&(this->timestamps),timestamps,sizeof(fullSmd2TimestampHead));
-	};
-	smd2Head::smd2Head(const rawSmd2Head*) {}; //TODO #26
-	rawSmd2Head *smd2Head::toRaw(rawSmd2Head*) {}; //TODO #27
+	}
+	smd2Head::smd2Head(const rawSmd2Head*) {} //TODO #26
+	rawSmd2Head *smd2Head::toRaw(rawSmd2Head*) {} //TODO #27
 	
 	unsigned int getSegmentSlotCountFromSMD2Size(const size_t size) {
 		return (size-sizeof(rawSmd2Head))/sizeof(rawCompressedSegment);
-	};
+	}
 	size_t getSMD2SizeFromSegmentSlotCount(const unsigned int slots) {
 		return sizeof(rawSmd2Head)+(slots*sizeof(rawCompressedSegment));
-	};
+	}
 }
 
 

--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -192,9 +192,24 @@ namespace smd2{
 		this->head=*head;
 		memcpy(&(this->blocks),blocks,sizeof(chunkData));
 	};
-	segment::segment(const struct segmentHead *head,const rawChunkData *blocks) {}; //TODO #9
+	
+	segment::segment(const struct segmentHead *head,const rawChunkData *blocks,const blocktypeList *list):
+	head(*head) {
+		for(unsigned int i = 0 ; i < 16 ; ++i)
+			for(unsigned int j = 0 ; j < 16 ; ++j)
+				for(unsigned int k = 0 ; k < 16 ; ++k)
+					this->blocks[i][j][k] = block(&(*blocks)[i][j][k], list);
+	};
+	
 	segment::segment(const struct segmentHead *head,const compressedChunkData *blocks) {}; //TODO #10
-	segment::segment(const struct rawSegment *src) {}; //TODO #9
+	segment::segment(const struct rawSegment *src,const blocktypeList *list):
+	head(src->head) {
+		for(unsigned int i = 0 ; i < 16 ; ++i)
+			for(unsigned int j = 0 ; j < 16 ; ++j)
+				for(unsigned int k = 0 ; k < 16 ; ++k)
+					blocks[i][j][k] = block(&(src->blocks)[i][j][k], list);
+	};
+	
 	segment::segment(const struct compressedSegment *src) {}; //TODO #10
 	segment::segment(const rawCompressedSegment *src) {}; //TODO #11
 	rawCompressedSegment *segment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {}; //TODO #12

--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -293,7 +293,22 @@ namespace smd2{
 			throw std::runtime_error("decompression failed");
 	}
 	
-	rawSegment::rawSegment(const rawCompressedSegment *src) {} //TODO #17
+	rawSegment::rawSegment(const rawCompressedSegment *src):
+	head(src, true) {
+		compressedChunkData blocks;
+		memcpy(blocks, src + sizeof(rawCompressedSegment)
+			   - sizeof(compressedChunkData),
+			   sizeof(compressedChunkData));
+		if(!inflate(&this->blocks, &blocks)) {
+			memcpy(blocks, src + sizeof(rawCompressedSegment)
+				   - sizeof(compressedChunkData) - 1,
+				   sizeof(compressedChunkData));
+			if(!inflate(&this->blocks, &blocks))
+				throw std::runtime_error("decompression failed");
+			head = segmentHead(src, false);
+		}
+	}
+	
 	rawCompressedSegment *rawSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {} //TODO #18
 	
 	compressedSegment::compressedSegment(const struct compressedSegment *copy) {

--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -83,8 +83,34 @@ namespace smd2{
 		return target;
 	};
 	
-	rawChunkData *inflate(rawChunkData *trg,const compressedChunkData *src) {}; //TODO #31
+	rawChunkData *inflate(rawChunkData *trg,const compressedChunkData *src) {
+		uLongf size = sizeof(rawChunkData);
+		Bytef buf[sizeof(rawChunkData)];
+		switch(uncompress(buf, &size, *src, sizeof(compressedChunkData))) {
+			case Z_OK:
+				break;
+			case Z_MEM_ERROR:
+				// zlib couldn't allocate enough memory
+			case Z_BUF_ERROR:
+				// the uncompressed data can't fit in the output buffer
+			case Z_DATA_ERROR:
+				// the compressed data is either uncomplete or corrupted
+			default:
+				// unknown error code
+				return nullptr;
+		}
+		for(unsigned int x = 0 ; x < 16 ; ++x)
+			for(unsigned int y = 0 ; y < 16 ; ++y)
+				for(unsigned int z = 0 ; z < 16 ; ++z) {
+					(*trg)[x][y][z][0]=buf[x+(16*y)+(256*z)];
+					(*trg)[x][y][z][1]=buf[x+(16*y)+(256*z)+1];
+					(*trg)[x][y][z][2]=buf[x+(16*y)+(256*z)+2];
+				}
+		return trg;
+	}
+	
 	compressedChunkData *deflate(compressedChunkData *trg,const rawChunkData *src) {}; //TODO #32
+	
 	bool isEmpty(const rawCompressedSegment *segment) {
 		size_t *chars=(size_t*)segment;
 		for(size_t i=0;i<(sizeof(rawCompressedSegment)/sizeof(size_t));i++) {

--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -24,7 +24,7 @@ namespace smd2{
 		this->orientation=orientation;
 	};
 	block::block(const rawBlock *raw, const blocktypeList *list) {
-		if(!list) std::__throw_invalid_argument("the provided list may not be NULL");
+		if(!list) throw std::invalid_argument("the provided list may not be NULL");
 		uint32_t buff=0;
 		memcpy(&buff+sizeof(uint32_t)-sizeof(rawBlock),raw,sizeof(rawBlock));
 		if(buff) {
@@ -33,7 +33,7 @@ namespace smd2{
 			buff>>=11;
 			blockType type=((blockType*)list)[this->id];
 			if(type==undefined) {
-				std::__throw_invalid_argument("blocktype not defined");
+				throw std::invalid_argument("blocktype not defined");
 			}
 			this->hp=buff;
 			if(type==fullyRotating) {
@@ -59,10 +59,10 @@ namespace smd2{
 		this->orientation=0;
 	};
 	rawBlock *block::toRaw(rawBlock *target, const blocktypeList *list) {
-		if(!list) std::__throw_invalid_argument("the provided list may not be NULL");
+		if(!list) throw std::invalid_argument("the provided list may not be NULL");
 		blockType type=((blockType*)list)[this->id];
 		if(type==undefined) {
-			std::__throw_invalid_argument("blocktype not defined");
+			throw std::invalid_argument("blocktype not defined");
 		}
 		uint32_t buff=this->orientation;
 		if(type==logic) {

--- a/src/SMD2Structs.cpp
+++ b/src/SMD2Structs.cpp
@@ -322,7 +322,14 @@ namespace smd2{
 	compressedSegment::compressedSegment(const struct segmentHead *head,const rawChunkData *blocks) {} //TODO #22
 	compressedSegment::compressedSegment(const struct segment *src) {} //TODO #21
 	compressedSegment::compressedSegment(const struct rawSegment *src) {} //TODO #22
-	compressedSegment::compressedSegment(const rawCompressedSegment *src) {} //TODO #23
+	
+	compressedSegment::compressedSegment(const rawCompressedSegment *src):
+	head(src, true) {
+		memcpy(blocks, src + sizeof(rawCompressedSegment)
+			   - sizeof(compressedChunkData),
+			   sizeof(compressedChunkData));
+	}
+	
 	rawCompressedSegment *compressedSegment::toRawCompressed(rawCompressedSegment *trg,const bool offset) {} //TODO #24
 	
 	

--- a/src/SMD2Structs.h
+++ b/src/SMD2Structs.h
@@ -54,11 +54,13 @@ namespace smd2{
 		chunkData blocks;
 		segment(const struct segment*);
 		segment(const struct segmentHead*,const chunkData*);
-		segment(const struct segmentHead*,const rawChunkData*,const blocktypeList*);
-		segment(const struct segmentHead*,const compressedChunkData*, const blocktypeList*);
+		segment(const struct segmentHead*,const rawChunkData*,
+				const blocktypeList*);
+		segment(const struct segmentHead*,const compressedChunkData*,
+				const blocktypeList*);
 		segment(const struct rawSegment*,const blocktypeList*);
 		segment(const struct compressedSegment*, const blocktypeList*);
-		segment(const rawCompressedSegment*);
+		segment(const rawCompressedSegment*, const blocktypeList*);
 		rawCompressedSegment *toRawCompressed(rawCompressedSegment*,const bool);
 	};
 	struct rawSegment {

--- a/src/SMD2Structs.h
+++ b/src/SMD2Structs.h
@@ -53,9 +53,9 @@ namespace smd2{
 		chunkData blocks;
 		segment(const struct segment*);
 		segment(const struct segmentHead*,const chunkData*);
-		segment(const struct segmentHead*,const rawChunkData*);
+		segment(const struct segmentHead*,const rawChunkData*,const blocktypeList*);
 		segment(const struct segmentHead*,const compressedChunkData*);
-		segment(const struct rawSegment*);
+		segment(const struct rawSegment*,const blocktypeList*);
 		segment(const struct compressedSegment*);
 		segment(const rawCompressedSegment*);
 		rawCompressedSegment *toRawCompressed(rawCompressedSegment*,const bool);

--- a/src/SMD2Structs.h
+++ b/src/SMD2Structs.h
@@ -9,6 +9,7 @@
 #define SMD2STRUCTS_H_
 
 #include <string.h>
+#include <zlib.h>
 
 namespace smd2{
 	enum blockType {
@@ -32,7 +33,7 @@ namespace smd2{
 	};
 	typedef rawBlock rawChunkData[16][16][16];
 	typedef struct block chunkData[16][16][16];
-	typedef char compressedChunkData[5094], rawCompressedSegment[5120];
+	typedef Bytef compressedChunkData[5094], rawCompressedSegment[5120];
 	rawChunkData *inflate(rawChunkData*,const compressedChunkData*);
 	compressedChunkData *deflate(compressedChunkData*,const rawChunkData*);
 	bool isEmpty(const rawCompressedSegment*);

--- a/src/SMD2Structs.h
+++ b/src/SMD2Structs.h
@@ -31,7 +31,7 @@ namespace smd2{
 		block();
 		rawBlock *toRaw(rawBlock*, const blocktypeList*);
 	};
-	typedef rawBlock rawChunkData[16][16][16];
+	typedef rawBlock rawChunkData[16][16][16]; // note: [Z][Y][X]
 	typedef struct block chunkData[16][16][16];
 	typedef Bytef compressedChunkData[5094], rawCompressedSegment[5120];
 	rawChunkData *inflate(rawChunkData*,const compressedChunkData*);
@@ -85,7 +85,7 @@ namespace smd2{
 		compressedSegment(const rawCompressedSegment*);
 		rawCompressedSegment *toRawCompressed(rawCompressedSegment*,const bool);
 	};
-	typedef char rawSmd2Head[65540], rawSmd2Index[8];
+	typedef Bytef rawSmd2Head[65540], rawSmd2Index[8];
 	typedef rawCompressedSegment smd2Body[4096];
 	struct smd2Index {
 				signed long id;

--- a/src/SMD2Structs.h
+++ b/src/SMD2Structs.h
@@ -55,9 +55,9 @@ namespace smd2{
 		segment(const struct segment*);
 		segment(const struct segmentHead*,const chunkData*);
 		segment(const struct segmentHead*,const rawChunkData*,const blocktypeList*);
-		segment(const struct segmentHead*,const compressedChunkData*);
+		segment(const struct segmentHead*,const compressedChunkData*, const blocktypeList*);
 		segment(const struct rawSegment*,const blocktypeList*);
-		segment(const struct compressedSegment*);
+		segment(const struct compressedSegment*, const blocktypeList*);
 		segment(const rawCompressedSegment*);
 		rawCompressedSegment *toRawCompressed(rawCompressedSegment*,const bool);
 	};


### PR DESCRIPTION
I had to add a blocktypeList\* argument to several functions.
I also changed the "byte" type used for  `compressedChunkData` `rawCompressedSegment` (formerly `char`) to zlib's `Bytef` (`unsigned char` on my machine) and removed the calls to `__throw_invalid_argument` (which didn't compile on my machine).
